### PR TITLE
fix: hmr on windows

### DIFF
--- a/src/vite-plugin-wayfinder.ts
+++ b/src/vite-plugin-wayfinder.ts
@@ -70,7 +70,7 @@ export const wayfinder = ({
             return runCommand();
         },
         handleHotUpdate({ file, server }) {
-            if (canRun(patterns, { file, server })) {
+            if (shouldRun(patterns, { file, server })) {
                 return runCommand();
             }
 
@@ -79,7 +79,7 @@ export const wayfinder = ({
     };
 };
 
-const canRun = (
+const shouldRun = (
     patterns: string[],
     opts: Pick<HmrContext, "file" | "server">,
 ): boolean => {

--- a/src/vite-plugin-wayfinder.ts
+++ b/src/vite-plugin-wayfinder.ts
@@ -3,7 +3,7 @@ import { minimatch } from "minimatch";
 import osPath from "path";
 import { PluginContext } from "rollup";
 import { promisify } from "util";
-import { Plugin } from "vite";
+import { Plugin, ViteDevServer } from "vite";
 
 const execAsync = promisify(exec);
 
@@ -70,20 +70,26 @@ export const wayfinder = ({
             return runCommand();
         },
         handleHotUpdate({ file, server }) {
-            if (
-                patterns.some((pattern) =>
-                    minimatch(
-                        file,
-                        osPath
-                            .resolve(server.config.root, pattern)
-                            .replaceAll("\\", "/"),
-                    ),
-                )
-            ) {
+            if (canRun(patterns, { file, server })) {
                 return runCommand();
             }
 
             return [];
         },
     };
+};
+
+const canRun = (
+    patterns: string[],
+    opts: { file: string; server: ViteDevServer },
+): boolean => {
+    const file = opts.file.replaceAll("\\", "/");
+
+    return patterns.some((pattern) => {
+        pattern = osPath
+            .resolve(opts.server.config.root, pattern)
+            .replaceAll("\\", "/");
+
+        return minimatch(file, pattern);
+    });
 };

--- a/src/vite-plugin-wayfinder.ts
+++ b/src/vite-plugin-wayfinder.ts
@@ -3,7 +3,7 @@ import { minimatch } from "minimatch";
 import osPath from "path";
 import { PluginContext } from "rollup";
 import { promisify } from "util";
-import { Plugin, ViteDevServer } from "vite";
+import { HmrContext, Plugin } from "vite";
 
 const execAsync = promisify(exec);
 
@@ -81,7 +81,7 @@ export const wayfinder = ({
 
 const canRun = (
     patterns: string[],
-    opts: { file: string; server: ViteDevServer },
+    opts: Pick<HmrContext, "file" | "server">,
 ): boolean => {
     const file = opts.file.replaceAll("\\", "/");
 


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This pull request reflects how [`vite-plugin-run`](https://github.com/innocenzi/vite-plugin-run) handles the HMR by adding a missing `.replaceAll` call on `file`, which should fix unexpected behaviour on Windows-like systems. It also includes a new helper function for better code readability and maintenance.

Fixes #1 