### PR TITLE
feat: add option to disable auto-generation

### DIFF
--- a/src/vite-plugin-wayfinder.ts
+++ b/src/vite-plugin-wayfinder.ts
@@ -14,6 +14,7 @@ interface WayfinderOptions {
     formVariants?: boolean;
     path?: string;
     command?: string;
+    generate?: boolean;
 }
 
 let context: PluginContext;
@@ -25,6 +26,7 @@ export const wayfinder = ({
     formVariants = false,
     path,
     command = "php artisan wayfinder:generate",
+    generate = true,
 }: WayfinderOptions = {}): Plugin => {
     patterns = patterns.map((pattern) => pattern.replace("\\", "/"));
 
@@ -53,6 +55,11 @@ export const wayfinder = ({
     }
 
     const runCommand = async () => {
+        if (!generate) {
+            context.info("Wayfinder auto-generation is disabled");
+            return;
+        }
+
         try {
             await execAsync(`${command} ${args.join(" ")}`);
         } catch (error) {


### PR DESCRIPTION
This pull request adds an option to control whether the Wayfinder auto-generation command should run automatically. The most important changes are grouped below:

**Wayfinder Plugin Configuration:**

* Added a new `generate` boolean option to the `WayfinderOptions` interface and the `wayfinder` plugin function, allowing users to enable or disable automatic generation. [[1]](diffhunk://#diff-3c5d752421d4ec0c04c1329e396df005878205846a0aa50879f9c40833b433daR17) [[2]](diffhunk://#diff-3c5d752421d4ec0c04c1329e396df005878205846a0aa50879f9c40833b433daR29)

**Plugin Behavior:**

* Updated the `runCommand` function to respect the new `generate` option: if `generate` is set to `false`, the plugin logs a message and skips running the generation command.
* This prevents errors in Docker development environments where the Node container does not have PHP installed, avoiding failed attempts to run php artisan wayfinder:generate inside Node.
* Developers can now manually run the command inside the PHP container when needed: `docker compose exec app php artisan wayfinder:generate --with-form`

**Motivation / Context:**

* Previously, the Wayfinder plugin would always attempt to execute the artisan command on dev start.
* In Docker setups where Node and PHP are in separate containers, this caused errors (/bin/sh: php: not found).
* The generate option allows Node-only dev containers to run Vite safely without PHP, while still supporting manual type generation in the PHP container.