### PR TITLE
Debounce and serialize type generation during dev

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -3,10 +3,10 @@ name: dependabot-auto-merge
 on: pull_request
 
 permissions:
-  contents: write
-  pull-requests: write
+    contents: write
+    pull-requests: write
 
 jobs:
-  dependabot:
-    if: ${{ github.actor == 'dependabot[bot]' }}
-    uses: laravel/.github/.github/workflows/dependabot-auto-merge.yml@c265c45c41ccb723befb7a2b807dffff4595bd39
+    dependabot:
+        if: ${{ github.actor == 'dependabot[bot]' }}
+        uses: laravel/.github/.github/workflows/dependabot-auto-merge.yml@c265c45c41ccb723befb7a2b807dffff4595bd39

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+pnpm-lock.yaml

--- a/src/vite-plugin-wayfinder.ts
+++ b/src/vite-plugin-wayfinder.ts
@@ -7,6 +7,8 @@ import { HmrContext, Plugin } from "vite";
 
 const execAsync = promisify(exec);
 
+const debounceMs = 100;
+
 interface WayfinderOptions {
     patterns?: string[];
     actions?: boolean;
@@ -52,7 +54,9 @@ export const wayfinder = ({
         args.push(`--path=${path}`);
     }
 
-    const runCommand = async () => {
+    let serving = false;
+
+    const generate = async () => {
         try {
             await execAsync(`${command} ${args.join(" ")}`);
         } catch (error) {
@@ -62,17 +66,59 @@ export const wayfinder = ({
         context.info(`Types generated for ${generating.join(", ")}`);
     };
 
+    // Two runs writing the same output directory at once can leave torn files,
+    // so every run queues behind the previous one.
+    let tail: Promise<void> = Promise.resolve();
+
+    const runCommand = () => {
+        const result = tail.then(generate, generate);
+
+        tail = result.catch(() => {});
+
+        return result;
+    };
+
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    let pending: Promise<void> | undefined;
+    let settle:
+        | { resolve: () => void; reject: (error: unknown) => void }
+        | undefined;
+
+    const scheduleCommand = () => {
+        pending ??= new Promise<void>((resolve, reject) => {
+            settle = { resolve, reject };
+        });
+
+        clearTimeout(timer);
+
+        timer = setTimeout(() => {
+            const { resolve, reject } = settle!;
+
+            pending = undefined;
+            settle = undefined;
+
+            runCommand().then(resolve, reject);
+        }, debounceMs);
+
+        return pending;
+    };
+
     return {
         name: "@laravel/vite-plugin-wayfinder",
         enforce: "pre",
+        configResolved(config) {
+            serving = config.command === "serve";
+        },
         buildStart() {
             context = this;
             return runCommand();
         },
-        async handleHotUpdate({ file, server }) {
-            if (shouldRun(patterns, { file, server })) {
-                await runCommand();
+        handleHotUpdate({ file, server }) {
+            if (!shouldRun(patterns, { file, server })) {
+                return;
             }
+
+            return serving ? scheduleCommand() : runCommand();
         },
     };
 };


### PR DESCRIPTION
`handleHotUpdate` fires once per changed file, so anything that touches several matched PHP files at once (a branch switch, a rebase, a format-on-save across a directory) started one `php artisan wayfinder:generate` per file, all running at the same time and all writing the same output directory.

Two changes. Hot updates during `vite dev` now go through a 100ms trailing debounce, so a burst collapses into a single run. Separately, every run queues behind the previous one, which covers the case the debounce cannot: a change landing while an earlier run is still going. Callers still await the real work, so HMR waits for generation as it did before.

The debounce only applies when serving. Builds and `buildStart` run immediately, as before.
